### PR TITLE
Fix retro compatibility with ADFastlane v6.1.0

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
@@ -966,7 +966,7 @@ struct HTMLTemplates
           <li onclick=\"showApplicationLogs(this);\">App Logs</li>
         </ul>
       </div>
-      <iframe id=\"test-logs-iframe\" src=\"test-logs-[[DEVICE_IDENTIFIER]].txt\"></iframe>
+      <iframe id=\"test-logs-iframe\" src=\"logs-[[DEVICE_IDENTIFIER]].txt\"></iframe>
       <iframe id=\"app-logs-iframe\" src=\"app-logs-[[DEVICE_IDENTIFIER]].txt\"></iframe>
     </div>
     <div id=\"design-review\">

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Run.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Run.swift
@@ -126,7 +126,7 @@ struct Run: HTML
             let activityLogs = logs[start..<end]
 
             do {
-                let file = "\(result.values.first!)/test-logs-\(runDestination.targetDevice.uniqueIdentifier).txt"
+                let file = "\(result.values.first!)/logs-\(runDestination.targetDevice.uniqueIdentifier).txt"
                 try activityLogs.write(toFile: file, atomically: false, encoding: .utf8)
             }
             catch let e {

--- a/XCTestHTMLReport/XCTestHTMLReport/HTML/run.html
+++ b/XCTestHTMLReport/XCTestHTMLReport/HTML/run.html
@@ -20,7 +20,7 @@
           <li onclick="showApplicationLogs(this);">App Logs</li>
         </ul>
       </div>
-      <iframe id="test-logs-iframe" src="test-logs-[[DEVICE_IDENTIFIER]].txt"></iframe>
+      <iframe id="test-logs-iframe" src="logs-[[DEVICE_IDENTIFIER]].txt"></iframe>
       <iframe id="app-logs-iframe" src="app-logs-[[DEVICE_IDENTIFIER]].txt"></iframe>
     </div>
     <div id="design-review">


### PR DESCRIPTION
Rename "test-logs" file into "logs" to fix retro compatibility with ADFastlane v6.1.0